### PR TITLE
chore: misc optimization and renaming in caliber

### DIFF
--- a/src/interfaces/ICaliber.sol
+++ b/src/interfaces/ICaliber.sol
@@ -36,7 +36,7 @@ interface ICaliber {
     event PositionCreated(uint256 indexed id);
     event PositionStaleThresholdChanged(uint256 indexed oldThreshold, uint256 indexed newThreshold);
     event RecoveryModeChanged(bool indexed enabled);
-    event SecurityCouncilChanged(address indexed oldSecurityCouncil, address indexed newecurityCouncil);
+    event SecurityCouncilChanged(address indexed oldSecurityCouncil, address indexed newSecurityCouncil);
     event TimelockDurationChanged(uint256 indexed oldDuration, uint256 indexed newDuration);
 
     enum InstructionType {

--- a/test/integration/concrete/caliber/manage-position/managePosition.t.sol
+++ b/test/integration/concrete/caliber/manage-position/managePosition.t.sol
@@ -297,7 +297,7 @@ contract ManagePosition_Integration_Concrete_Test is Caliber_Integration_Concret
         instructions[1] = WeirollUtils._buildMockPoolAccountingInstruction(address(caliber), POOL_POS_ID, address(pool));
 
         vm.prank(mechanic);
-        vm.expectRevert(ICaliber.InvalidAccounting.selector);
+        vm.expectRevert(ICaliber.InvalidAffectedToken.selector);
         caliber.managePosition(instructions);
     }
 

--- a/test/integration/concrete/caliber/manage-position/managePosition.tree
+++ b/test/integration/concrete/caliber/manage-position/managePosition.tree
@@ -37,7 +37,7 @@ managePosition.t.sol
 │                                   │  └── it should revert with InvalidAccounting
 │                                   └── given the second instruction outputs a valid state
 │                                      ├── when the second instruction's affected tokens list contains non-base tokens
-│                                      │  └── it should revert with InvalidAccounting
+│                                      │  └── it should revert with InvalidAffectedToken
 │                                      └── when the second instruction's affected tokens list only contains base tokens
 │                                         ├── given the position value did not decrease
 │                                         │  ├── given the new position value is zero


### PR DESCRIPTION
Some optimization :
- In `Caliber.managePosition()`, compute `inputTokensValueBefore` only when recovery mode is off.
- In `Caliber.managePosition()`, merge `if` conditions for more concision.

Some renaming : 
- in `_accountForPosition()`, replace `InvalidAccounting` occurence by `InvalidAffectedToken` for more clarity. Update corresponding test and .tree file.